### PR TITLE
Change jquery-ui dependency to official repository

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,6 @@
 	],
 	"dependencies": {
 		"jquery": ">=1.7.0",
-		"jqueryui": ">=1.9.0"
+		"jquery-ui": ">=1.9.0"
 	}
 }


### PR DESCRIPTION
Using jqueryui (https://github.com/components/jqueryui/) instead jquery-ui (https://github.com/jquery/jquery-ui) causes doubling of that library required by bower.
