### PR TITLE
Changed load() fn to on() since load is deprecatedy

### DIFF
--- a/jquery.coverflow.js
+++ b/jquery.coverflow.js
@@ -85,7 +85,7 @@
 			
 			// Fix height
 			that.element.height(maxHeight);
-			images.load(function() {
+			images.on(function() {
 				height = that._getCovers().height();
 				if (height > maxHeight) {
 					maxHeight = height;


### PR DESCRIPTION
Was trying to integrate this with site, using jQuery 3.1.1 and it shot an error saying that load is deprecated, after changing it locally it worked.
Please confirm.
Thanks
P.S If this is an actual issue, this might be my first contribution to something open source on GitHub :p