### PR TITLE
Add manual npm publish trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,12 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Package version to publish (with optional v prefix)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -26,11 +32,17 @@ jobs:
 
       - name: Verify release version
         shell: bash
+        env:
+          MANUAL_VERSION: ${{ inputs.version }}
         run: |
-          release_version="${GITHUB_REF_NAME#v}"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            release_version="${MANUAL_VERSION#v}"
+          else
+            release_version="${GITHUB_REF_NAME#v}"
+          fi
           package_version="$(node -p "require('./package.json').version")"
           if [[ "$release_version" != "$package_version" ]]; then
-            echo "Release tag version ($release_version) does not match package.json ($package_version)."
+            echo "Requested version ($release_version) does not match package.json ($package_version)."
             exit 1
           fi
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -16,3 +16,5 @@ Releases are published as [`jquery.coverflow`](https://www.npmjs.com/package/jqu
 3. Publish the GitHub release. Prereleases are intentionally skipped.
 
 The workflow verifies the tag, tests the package, and publishes it with npm provenance. A version can only be published once.
+
+If GitHub does not start the workflow for an existing release, run the `Publish to npm` workflow manually from the Actions tab and enter the package version. The same version check and publishing steps apply.


### PR DESCRIPTION
## Summary

- add a manual dispatch trigger to the npm publishing workflow
- require the requested package version as an input
- apply the existing package/version guard to release and manual runs
- document the manual recovery path

## Why

GitHub recorded the publication of the pre-existing `1.3.5` release but did not schedule the release-triggered workflow. A manual trigger provides a safe recovery path without deleting and recreating the release.

## Validation

- `node --check jquery.coverflow.js`
- `git diff --check`
- verified the requested version is normalized and compared with `package.json` before publishing
