### PR TITLE
Fix Firefox cover transform scaling

### DIFF
--- a/jquery.coverflow.js
+++ b/jquery.coverflow.js
@@ -321,7 +321,10 @@
 				
 				//@todo Test CSS for middle behaviour (or does $.interpolate handle it?)
 
-				transform = 'scale(' + scale + ',' + scale + ') perspective(' + (parentWidth * 0.5) + 'px) rotateY(' + angle + 'deg)';
+				// Transform functions are applied from right to left. Scale the cover
+				// before rotating it so perspective is calculated from its displayed
+				// size instead of its full dimensions (which can balloon in Firefox).
+				transform = 'perspective(' + (parentWidth * 0.5) + 'px) rotateY(' + angle + 'deg) scale(' + scale + ',' + scale + ')';
 				
 				$cover[isMiddle ? 'addClass' : 'removeClass']('current');
 				$cover[isVisible ? 'show' : 'hide']();				


### PR DESCRIPTION
## Summary

- apply cover scaling before rotation and perspective projection
- document why transform order matters for Firefox rendering

## Why

CSS transform functions are applied from right to left. The previous order rotated and projected each cover at its full intrinsic dimensions before scaling the result down. In Firefox, the near edge of an angled cover could therefore balloon across the viewport during transitions, matching the screenshots in issue #43.

The new order scales the cover first, then rotates it, and finally applies perspective. This keeps perspective geometry based on the displayed cover size without changing callbacks or layout calculations.

Closes #43.

## Validation

- `node --check jquery.coverflow.js`
- verified the generated transform order is `perspective(...) rotateY(...) scale(...)`
- `git diff --check`

The package runner attempted to fetch the legacy jQuery dependencies in this clean checkout, so the syntax-only test command was executed directly without installing dependencies.
