### PR TITLE
Document safe dynamic reflection updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,22 @@ returned. Otherwise, the index will be set to the provided value.
 Redraw the covers. You shouldn't ever need to do this unless you are adding
 or removing covers or changing the covers yourself.
 
+When adding covers dynamically, append the new DOM node instead of rewriting
+the coverflow's `innerHTML`. Rewriting `innerHTML` recreates every existing
+node, which clears canvas-based reflections and discards plugin state. Apply
+the reflection plugin to the new cover before refreshing:
+
+```js
+var $cover = $('<img class="cover" src="demo/attic.jpg" alt="">')
+    .appendTo('#preview-coverflow');
+
+if ($.fn.reflect) {
+    $cover.reflect();
+}
+
+$('#preview-coverflow').coverflow('refresh');
+```
+
 Events
 ------
 ### **before**


### PR DESCRIPTION
## Summary

- document how to add covers dynamically without losing reflections
- provide a complete append, reflect, and refresh example
- warn against rewriting the coverflow's `innerHTML`

## Why

The pattern in issue #14 reads and rewrites the container's entire `innerHTML`. That recreates every cover and reflection node. Canvas pixel content is not represented in serialized HTML, and the reflection plugin's jQuery state is attached to the original DOM nodes, so neither can survive that replacement.

Appending the new image in place preserves all existing nodes. Applying the reflection plugin to only the new image before calling `coverflow('refresh')` integrates it with the existing reflected covers.

Closes #14.

## Validation

- `node --check jquery.coverflow.js`
- `git diff --check`
- verified the example preserves existing DOM nodes and initializes the new reflection before refresh
